### PR TITLE
Update Content-Type header to application/json in response macros

### DIFF
--- a/src/app/Macros/ResponseMacros.php
+++ b/src/app/Macros/ResponseMacros.php
@@ -70,7 +70,7 @@ class ResponseMacros
             }
 
             return response($result, $status)
-                ->header('Content-Type', 'text/json')
+                ->header('Content-Type', 'application/json')
                 ->header('Content-Length', strval(strlen($result)));
         });
 
@@ -93,7 +93,7 @@ class ResponseMacros
             $result = str_replace('"RAW"', $raw, $result);
 
             return response($result, $status)
-                ->header('Content-Type', 'text/json')
+                ->header('Content-Type', 'application/json')
                 ->header('Content-Length', strval(strlen($result)));
         });
 


### PR DESCRIPTION
This PR updates the `Content-Type` header in the `response()->api()` and related macros from `text/json` to the correct MIME type `application/json`.

Note: This was indicated by Simão since he was having some issues on the response format while using `Nuxt`.

For more information visit [mimetype.io](https://mimetype.io/text/json)