### PR TITLE
Fix type hint in FilterCustom

### DIFF
--- a/src/app/Macros/Filterable/FilterCustom.php
+++ b/src/app/Macros/Filterable/FilterCustom.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 class FilterCustom implements FilterableContract
 {
     /**
-     * @param  array<string, mixed>  $dependencies
+     * @param  array<int, string>  $dependencies
      */
     public function __construct(
         public string $column,
@@ -28,7 +28,7 @@ class FilterCustom implements FilterableContract
     /**
      * Make Custom Filter with other column dependancy
      *
-     * @param  array<string, mixed>  $dependencies
+     * @param  array<int, string>  $dependencies
      */
     public static function makeWith(string $column, array $dependencies, Closure $closure, bool $callAlways = false): FilterCustom
     {


### PR DESCRIPTION
Ideally, instead of `array<int, string>` it should be `array<filters present in the current request>` but don't think there's anything like that out of the box.